### PR TITLE
feat: basic auth via CredentialsProvider

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -22,12 +23,20 @@ import (
 	"go.withmatt.com/connect-etcd/types/etcdserverpb/etcdserverpbconnect"
 )
 
+// CredentialsProvider returns the username and password for Basic Auth.
+//
+// It is called on each request, including each unary retry attempt and each
+// new streaming RPC, so it may return different values over time to support
+// credential rotation. Implementations must be safe for concurrent use.
+type CredentialsProvider func() (username, password string)
+
 type Config struct {
 	Endpoints    []string
 	TLSConfig    *tls.Config
 	Logger       log.LeveledLogger
 	RetryOptions *RetryOptions
 	DialContext  func(context.Context, string, string) (net.Conn, error)
+	Credentials  CredentialsProvider
 }
 
 type LeveledLogger = log.LeveledLogger
@@ -153,20 +162,34 @@ var defaultRetryOptions = &RetryOptions{
 }
 
 func clientOptions(cfg Config) []connect.ClientOption {
-	opts := defaultClientOpts
+	opts := append([]connect.ClientOption{}, defaultClientOpts...)
+	interceptors := clientInterceptors(cfg)
+	if len(interceptors) == 0 {
+		return opts
+	}
+	return append(opts, connect.WithInterceptors(interceptors...))
+}
+
+func clientInterceptors(cfg Config) []connect.Interceptor {
 	retryOpts := cfg.RetryOptions
 	if retryOpts == nil {
 		retryOpts = defaultRetryOptions
 	}
-	if retryOpts.UnaryAttempts == 0 {
-		return opts
+	interceptors := make([]connect.Interceptor, 0, 2)
+	if retryOpts.UnaryAttempts > 0 {
+		interceptors = append(interceptors, retry.UnaryInterceptor(
+			cfg.Logger,
+			retryOpts.UnaryAttempts,
+			retryOpts.Interval,
+			retryOpts.Jitter,
+		))
 	}
-	return append(opts, connect.WithInterceptors(retry.UnaryInterceptor(
-		cfg.Logger,
-		retryOpts.UnaryAttempts,
-		retryOpts.Interval,
-		retryOpts.Jitter,
-	)))
+	if cfg.Credentials != nil {
+		interceptors = append(interceptors, &basicAuthInterceptor{
+			credentials: cfg.Credentials,
+		})
+	}
+	return interceptors
 }
 
 // likely adopt go-upstream here
@@ -256,4 +279,34 @@ func NextKey(key []byte) []byte {
 	// next prefix does not exist (e.g., 0xffff);
 	// default to WithFromKey policy
 	return []byte{0}
+}
+
+type basicAuthInterceptor struct {
+	credentials CredentialsProvider
+}
+
+func (i *basicAuthInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		username, password := i.credentials()
+		setBasicAuthHeader(req.Header(), username, password)
+		return next(ctx, req)
+	}
+}
+
+func (i *basicAuthInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return func(ctx context.Context, spec connect.Spec) connect.StreamingClientConn {
+		conn := next(ctx, spec)
+		username, password := i.credentials()
+		setBasicAuthHeader(conn.RequestHeader(), username, password)
+		return conn
+	}
+}
+
+func (i *basicAuthInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return next
+}
+
+func setBasicAuthHeader(header http.Header, username, password string) {
+	auth := username + ":" + password
+	header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(auth)))
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,196 @@
+package etcd
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"testing"
+
+	"connectrpc.com/connect"
+)
+
+func TestBasicAuthInterceptorWrapUnarySetsAuthorizationHeaderPerRequest(t *testing.T) {
+	t.Parallel()
+
+	credentials := []struct {
+		username string
+		password string
+	}{
+		{username: "alice", password: "first"},
+		{username: "bob", password: "second"},
+	}
+	var calls int
+
+	interceptor := &basicAuthInterceptor{
+		credentials: func() (string, string) {
+			creds := credentials[calls]
+			calls++
+			return creds.username, creds.password
+		},
+	}
+
+	var got []string
+	next := interceptor.WrapUnary(func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		got = append(got, req.Header().Get("Authorization"))
+		return connect.NewResponse(&struct{}{}), nil
+	})
+
+	for range credentials {
+		if _, err := next(context.Background(), connect.NewRequest(&struct{}{})); err != nil {
+			t.Fatalf("next() error = %v", err)
+		}
+	}
+
+	want := []string{
+		basicAuthHeader("alice", "first"),
+		basicAuthHeader("bob", "second"),
+	}
+	if calls != len(credentials) {
+		t.Fatalf("credentials provider calls = %d, want %d", calls, len(credentials))
+	}
+	if len(got) != len(want) {
+		t.Fatalf("captured headers = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("header %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestBasicAuthInterceptorWrapStreamingClientSetsAuthorizationHeaderPerStream(t *testing.T) {
+	t.Parallel()
+
+	credentials := []struct {
+		username string
+		password string
+	}{
+		{username: "watcher", password: "first"},
+		{username: "watcher", password: "rotated"},
+	}
+	var calls int
+
+	interceptor := &basicAuthInterceptor{
+		credentials: func() (string, string) {
+			creds := credentials[calls]
+			calls++
+			return creds.username, creds.password
+		},
+	}
+
+	wrapped := interceptor.WrapStreamingClient(func(ctx context.Context, spec connect.Spec) connect.StreamingClientConn {
+		return &stubStreamingClientConn{
+			requestHeader:   make(http.Header),
+			responseHeader:  make(http.Header),
+			responseTrailer: make(http.Header),
+		}
+	})
+
+	stream1 := wrapped(context.Background(), connect.Spec{})
+	stream2 := wrapped(context.Background(), connect.Spec{})
+
+	got := []string{
+		stream1.RequestHeader().Get("Authorization"),
+		stream2.RequestHeader().Get("Authorization"),
+	}
+	want := []string{
+		basicAuthHeader("watcher", "first"),
+		basicAuthHeader("watcher", "rotated"),
+	}
+
+	if calls != len(credentials) {
+		t.Fatalf("credentials provider calls = %d, want %d", calls, len(credentials))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("stream header %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestClientInterceptorsIncludeCredentialsWithoutRetry(t *testing.T) {
+	t.Parallel()
+
+	interceptors := clientInterceptors(Config{
+		RetryOptions: NoRetry,
+		Credentials: func() (string, string) {
+			return "user", "pass"
+		},
+	})
+
+	if len(interceptors) != 1 {
+		t.Fatalf("len(interceptors) = %d, want 1", len(interceptors))
+	}
+	if _, ok := interceptors[0].(*basicAuthInterceptor); !ok {
+		t.Fatalf("interceptors[0] = %T, want *basicAuthInterceptor", interceptors[0])
+	}
+}
+
+func TestClientInterceptorsOrderRetryBeforeCredentials(t *testing.T) {
+	t.Parallel()
+
+	interceptors := clientInterceptors(Config{
+		RetryOptions: &RetryOptions{
+			UnaryAttempts: 1,
+		},
+		Credentials: func() (string, string) {
+			return "user", "pass"
+		},
+	})
+
+	if len(interceptors) != 2 {
+		t.Fatalf("len(interceptors) = %d, want 2", len(interceptors))
+	}
+	if _, ok := interceptors[0].(connect.UnaryInterceptorFunc); !ok {
+		t.Fatalf("interceptors[0] = %T, want connect.UnaryInterceptorFunc", interceptors[0])
+	}
+	if _, ok := interceptors[1].(*basicAuthInterceptor); !ok {
+		t.Fatalf("interceptors[1] = %T, want *basicAuthInterceptor", interceptors[1])
+	}
+}
+
+func basicAuthHeader(username, password string) string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
+}
+
+type stubStreamingClientConn struct {
+	requestHeader   http.Header
+	responseHeader  http.Header
+	responseTrailer http.Header
+}
+
+func (s *stubStreamingClientConn) Spec() connect.Spec {
+	return connect.Spec{}
+}
+
+func (s *stubStreamingClientConn) Peer() connect.Peer {
+	return connect.Peer{}
+}
+
+func (s *stubStreamingClientConn) Send(any) error {
+	return nil
+}
+
+func (s *stubStreamingClientConn) RequestHeader() http.Header {
+	return s.requestHeader
+}
+
+func (s *stubStreamingClientConn) CloseRequest() error {
+	return nil
+}
+
+func (s *stubStreamingClientConn) Receive(any) error {
+	return nil
+}
+
+func (s *stubStreamingClientConn) ResponseHeader() http.Header {
+	return s.responseHeader
+}
+
+func (s *stubStreamingClientConn) ResponseTrailer() http.Header {
+	return s.responseTrailer
+}
+
+func (s *stubStreamingClientConn) CloseResponse() error {
+	return nil
+}


### PR DESCRIPTION
Add a `CredentialsProvider` func type to `Config` that supplies username and password for HTTP Basic Auth. The provider is called on every unary attempt and every new streaming RPC, so credentials can rotate without recreating the client.

`clientOptions` was mutating `defaultClientOpts` in place (slice append into a package-level var). Fixed that with a copy before appending.

`clientInterceptors` now builds the interceptor slice independently of `clientOptions`, making it testable. Retry comes before auth so retries carry fresh credentials from the provider.

Tests cover header injection per-request and per-stream, auth-only (no retry) config, and interceptor ordering.