### PR TITLE
Detect etcd compaction problems

### DIFF
--- a/cache/informer.go
+++ b/cache/informer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"connectrpc.com/connect"
@@ -29,7 +30,7 @@ type Informer struct {
 	cacheLock sync.RWMutex
 	cache     map[string]*mvccpb.KeyValue
 
-	lastRevision int64
+	lastRevision atomic.Int64
 	totalKeys    uint64
 
 	syncDoneMu sync.Mutex
@@ -44,7 +45,7 @@ func nextKey(key []byte) []byte {
 }
 
 func (i *Informer) LastRevision() int64 {
-	return i.lastRevision
+	return i.lastRevision.Load()
 }
 
 func (i *Informer) addFunc(kv *mvccpb.KeyValue) {
@@ -115,7 +116,7 @@ func (i *Informer) load(ctx context.Context) error {
 	l := i.Client.Logger()
 
 	i.cache = make(map[string]*mvccpb.KeyValue)
-	i.lastRevision = 0
+	i.lastRevision.Store(0)
 	i.totalKeys = 0
 
 	pageSize := i.ListPageSize
@@ -125,6 +126,7 @@ func (i *Informer) load(ctx context.Context) error {
 
 	startKey := i.Key
 
+	var lastRevision int64
 	var limit int64
 	var serializable bool
 
@@ -132,7 +134,7 @@ func (i *Informer) load(ctx context.Context) error {
 		if l.CheckDebug() {
 			l.Debug("Range",
 				"key", string(startKey),
-				"revision", i.lastRevision,
+				"revision", lastRevision,
 			)
 		}
 
@@ -143,7 +145,7 @@ func (i *Informer) load(ctx context.Context) error {
 		// starting state for pagination. Once we have a revision, we can
 		// serve the rest of the pages from a replica with an explicit
 		// revision.
-		if i.lastRevision == 0 {
+		if lastRevision == 0 {
 			limit = min(pageSize, defaultPageSize)
 			serializable = false
 		} else {
@@ -157,7 +159,7 @@ func (i *Informer) load(ctx context.Context) error {
 			Key:          startKey,
 			RangeEnd:     i.RangeEnd,
 			Limit:        limit,
-			Revision:     i.lastRevision,
+			Revision:     lastRevision,
 			Serializable: serializable,
 		}))
 		if err != nil {
@@ -166,8 +168,8 @@ func (i *Informer) load(ctx context.Context) error {
 		}
 		msg := resp.Msg
 
-		if i.lastRevision == 0 {
-			i.lastRevision = msg.Header.Revision
+		if lastRevision == 0 {
+			lastRevision = msg.Header.Revision
 		}
 
 		for _, kv := range msg.Kvs {
@@ -181,6 +183,7 @@ func (i *Informer) load(ctx context.Context) error {
 		startKey = nextKey(msg.Kvs[len(msg.Kvs)-1].Key)
 	}
 
+	i.lastRevision.Store(lastRevision)
 	i.cacheLock.Unlock()
 
 	// send out the AddFunc calls after we've successfully synced
@@ -226,7 +229,7 @@ func (i *Informer) Run(ctx context.Context) error {
 		l.Info(
 			"informer sync finished",
 			"total_keys", i.totalKeys,
-			"revision", i.lastRevision,
+			"revision", i.lastRevision.Load(),
 			"duration", time.Since(start),
 		)
 	}
@@ -248,7 +251,8 @@ func (i *Informer) stream(ctx context.Context) error {
 	stream := i.Client.Watch().Watch(ctx)
 	defer stream.CloseRequest()
 
-	startRevision := i.lastRevision + 1
+	lastRevision := i.lastRevision.Load()
+	startRevision := lastRevision + 1
 	if err := stream.Send(&etcdserverpb.WatchRequest{
 		RequestUnion: &etcdserverpb.WatchRequest_CreateRequest{
 			CreateRequest: &etcdserverpb.WatchCreateRequest{
@@ -290,7 +294,7 @@ func (i *Informer) stream(ctx context.Context) error {
 			"raft_term", msg.Header.RaftTerm,
 		)
 	}
-	i.lastRevision = msg.Header.Revision
+	lastRevision = msg.Header.Revision
 
 	errCh := make(chan error)
 
@@ -321,14 +325,14 @@ func (i *Informer) stream(ctx context.Context) error {
 					"member_id", msg.Header.MemberId,
 					"revision", msg.Header.Revision,
 					"raft_term", msg.Header.RaftTerm,
-					"last_revision", i.lastRevision,
+					"last_revision", lastRevision,
 					"events", len(msg.Events),
 					"fragment", msg.Fragment,
 				)
 			}
 
-			if msg.Header.Revision < i.lastRevision {
-				errCh <- fmt.Errorf("informer: older revision observed: %d -> %d", i.lastRevision, msg.Header.Revision)
+			if msg.Header.Revision < lastRevision {
+				errCh <- fmt.Errorf("informer: older revision observed: %d -> %d", lastRevision, msg.Header.Revision)
 				return
 			}
 
@@ -349,7 +353,8 @@ func (i *Informer) stream(ctx context.Context) error {
 				i.cacheLock.Unlock()
 			}
 
-			i.lastRevision = msg.Header.Revision
+			lastRevision = msg.Header.Revision
+			i.lastRevision.Store(lastRevision)
 		}
 	}()
 

--- a/cache/informer.go
+++ b/cache/informer.go
@@ -30,8 +30,9 @@ type Informer struct {
 	cacheLock sync.RWMutex
 	cache     map[string]*mvccpb.KeyValue
 
-	lastRevision atomic.Int64
-	totalKeys    uint64
+	streamsAttempted atomic.Int64
+	lastRevision     atomic.Int64
+	totalKeys        uint64
 
 	syncDoneMu sync.Mutex
 	syncDone   chan error
@@ -46,6 +47,10 @@ func nextKey(key []byte) []byte {
 
 func (i *Informer) LastRevision() int64 {
 	return i.lastRevision.Load()
+}
+
+func (i *Informer) StreamsAttempted() int64 {
+	return i.streamsAttempted.Load()
 }
 
 func (i *Informer) addFunc(kv *mvccpb.KeyValue) {
@@ -251,8 +256,10 @@ func (i *Informer) stream(ctx context.Context) error {
 	stream := i.Client.Watch().Watch(ctx)
 	defer stream.CloseRequest()
 
-	lastRevision := i.lastRevision.Load()
-	startRevision := lastRevision + 1
+	i.streamsAttempted.Add(1)
+
+	startRevision := i.lastRevision.Load() + 1
+
 	if err := stream.Send(&etcdserverpb.WatchRequest{
 		RequestUnion: &etcdserverpb.WatchRequest_CreateRequest{
 			CreateRequest: &etcdserverpb.WatchCreateRequest{
@@ -294,7 +301,7 @@ func (i *Informer) stream(ctx context.Context) error {
 			"raft_term", msg.Header.RaftTerm,
 		)
 	}
-	lastRevision = msg.Header.Revision
+	lastRevision := msg.Header.Revision
 
 	errCh := make(chan error)
 

--- a/cache/informer.go
+++ b/cache/informer.go
@@ -86,6 +86,27 @@ func (i *Informer) List() [][]byte {
 	return l
 }
 
+type CompactedError struct {
+	Reason            string
+	CompactedRevision int64
+	RequestedRevision int64
+}
+
+func (e *CompactedError) Error() string {
+	return fmt.Sprintf("informer: stream canceled: %q (compacted revision %d > start revision %d)", e.Reason, e.CompactedRevision, e.RequestedRevision)
+}
+
+func streamHeaderCanceledError(reason string, compactedRevision, startRevision int64) error {
+	if compactedRevision > startRevision {
+		return &CompactedError{
+			Reason:            reason,
+			CompactedRevision: compactedRevision,
+			RequestedRevision: startRevision,
+		}
+	}
+	return fmt.Errorf("informer: stream canceled: %s", reason)
+}
+
 const defaultPageSize = 100
 
 func (i *Informer) load(ctx context.Context) error {
@@ -227,11 +248,12 @@ func (i *Informer) stream(ctx context.Context) error {
 	stream := i.Client.Watch().Watch(ctx)
 	defer stream.CloseRequest()
 
+	startRevision := i.lastRevision + 1
 	if err := stream.Send(&etcdserverpb.WatchRequest{
 		RequestUnion: &etcdserverpb.WatchRequest_CreateRequest{
 			CreateRequest: &etcdserverpb.WatchCreateRequest{
 				WatchId:       watchId,
-				StartRevision: i.lastRevision + 1,
+				StartRevision: startRevision,
 				Key:           i.Key,
 				RangeEnd:      i.RangeEnd,
 
@@ -253,6 +275,10 @@ func (i *Informer) stream(ctx context.Context) error {
 
 	if !msg.Created {
 		return errors.New("informer: unexpected watch message, expected CreateResponse")
+	}
+
+	if msg.Canceled {
+		return streamHeaderCanceledError(msg.CancelReason, msg.CompactRevision, startRevision)
 	}
 
 	if l.CheckDebug() {
@@ -284,6 +310,7 @@ func (i *Informer) stream(ctx context.Context) error {
 			}
 
 			if msg.Canceled {
+				errCh <- fmt.Errorf("informer: stream canceled: %q", msg.CancelReason)
 				return
 			}
 

--- a/example/cache/main.go
+++ b/example/cache/main.go
@@ -23,8 +23,8 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 
-	c := client.New(&client.Config{
-		Endpoint: "127.0.0.1:2379",
+	c := client.NewClient(client.Config{
+		Endpoints: []string{"127.0.0.1:2379"},
 	})
 
 	i := cache.Informer{

--- a/example/main.go
+++ b/example/main.go
@@ -38,8 +38,8 @@ func main() {
 			panic(err)
 		}
 	}
-	c := client.New(&client.Config{
-		Endpoints: "127.0.0.1:2379",
+	c := client.NewClient(client.Config{
+		Endpoints: []string{"127.0.0.1:2379"},
 		TLSConfig: tlsConfig,
 	})
 
@@ -52,12 +52,10 @@ func main() {
 
 	// first create our watch stream
 	// r := client.Retryer(c.Watch()).Watch(context.Background())
-	stream := client.Retryer(context.TODO(), c.Watch()).Watch(context.Background())
+	stream := c.Watch().Watch(context.Background())
 	go func() {
 		defer func() {
-			stream.Close()
-			// stream.CloseRequest()
-			// stream.CloseResponse()
+			stream.CloseRequest()
 			close(done)
 		}()
 


### PR DESCRIPTION
This branch does two main things in `cache/informer.go`:

1. If an etcd watch stream responds with the `Canceled` flag set, return an error. We only want to stop streaming if the caller has told us to stop streaming. Canceled is most likely to be set on the initial WatchResponse in cases like when etcd has compacted past the revision that the client asked for. 
2. Add a counter for how many times the stream has been restarted. If this is in a retry loop, the counter will increase rapidly. This will let clients detect that the etcd server is not working or that a stream is not possible due to compaction.
